### PR TITLE
Fix Fushuma block confirmations from 66 to 6

### DIFF
--- a/src/app/constants/config.ts
+++ b/src/app/constants/config.ts
@@ -15,7 +15,7 @@ export const blockConfirmations: { [chainId: number]: number } = {
   '56': 5,
   '1': 6,
   '137': 302,
-  '121224': 66,
+  '121224': 6,
   '8453': 302,
   '130': 602,
   '42161': 1202


### PR DESCRIPTION
The block confirmations for Fushuma (chainId 121224) was incorrectly set to 66 blocks instead of 6. This caused unnecessary wait times for users bridging from Fushuma.