### PR TITLE
Fix claim failure when a signature server returns 403/CORS error

### DIFF
--- a/src/app/utils/getSignatures.ts
+++ b/src/app/utils/getSignatures.ts
@@ -7,71 +7,68 @@ export const sigs = [
 
 export const requiredSignatures = 3;
 
-const fetchSig = async (url: string) => {
-  try {
-    const res = await fetch(url);
-    return res;
-  } catch (e) {
-    console.log(e);
-    setTimeout(async () => {
-      return await fetchSig(url);
-    }, 1000);
+const MAX_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 1000;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Fetch a single signature endpoint and return its parsed JSON body.
+// Returns `null` instead of throwing when a server is unreachable, blocked by
+// CORS, responds with an HTTP error (e.g. 403), or returns an unparsable body.
+// This keeps one misbehaving server from aborting the whole signature round and
+// avoids the fire-and-forget background retry loop the previous version spawned.
+const fetchSigJSON = async (url: string): Promise<any | null> => {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        // HTTP error (403/5xx/etc). Don't retry – it won't recover in time.
+        console.warn(`Signature server responded with ${res.status}: ${url}`);
+        return null;
+      }
+      return await res.json();
+    } catch (e) {
+      // Network / CORS failure. Retry once for transient blips, then give up.
+      console.warn(`Signature server request failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${url}`, e);
+      if (attempt < MAX_ATTEMPTS) {
+        await delay(RETRY_DELAY_MS);
+      }
+    }
   }
+  return null;
 };
 
-const getSignaturesClaim = async (hash: string, chainId: string) => {
+const collectSignatures = async (buildUrl: (base: string) => string) => {
   const signatures: any[] = [];
   let respJSON: any;
 
-  async function checkSignature(i: number) {
-    const url = `${sigs[i]}auth?tx=${hash}&chain=${chainId}`;
-    const resp = await fetchSig(url);
-    respJSON = await resp.json();
-
-    if (respJSON.isSuccess) {
-      signatures.push(respJSON.signature);
-      if (signatures.length >= requiredSignatures) {
-        return { signatures, respJSON };
-      }
-    }
-
-    // Some tests showed that this could cause infinite loop
-
-    // else if (respJSON.message.includes('Confirming')) {
-    //   return new Promise((resolve) => {
-    //     setTimeout(async () => {
-    //       const result = await checkSignature(i);
-    //       resolve(result);
-    //     }, 1000);
-    //   });
-    // }
-  }
-
   for (let i = 0; i < sigs.length; i++) {
-    await checkSignature(i);
+    if (signatures.length >= requiredSignatures) break;
+
+    const json = await fetchSigJSON(buildUrl(sigs[i]));
+    if (json && json.isSuccess) {
+      respJSON = json;
+      signatures.push(json.signature);
+    }
   }
 
   return { signatures, respJSON };
 };
 
+const getSignaturesClaim = async (hash: string, chainId: string) => {
+  return collectSignatures((base) => `${base}auth?tx=${hash}&chain=${chainId}`);
+};
+
 export const getSignaturesAddWrapped = async (token: `0x${string}`, chainId: number) => {
-  const signatures: any[] = [];
-  let respJSON: any;
+  const { signatures, respJSON } = await collectSignatures(
+    (base) => `${base}addToken?token=${token}&chain=${chainId}`
+  );
 
-  for (let i = 0; i < sigs.length; i++) {
-    const url = `${sigs[i]}addToken?token=${token}&chain=${chainId}`;
-    const resp = await fetchSig(url);
-    respJSON = await resp.json();
-
-    if (respJSON.isSuccess) {
-      signatures.push(respJSON.signature);
-      if (signatures.length >= requiredSignatures) {
-        return { signatures, respJSON };
-      }
-    }
+  if (signatures.length < requiredSignatures) {
+    return { signatures: [], respJSON };
   }
 
-  return { signatures: [], respJSON };
+  return { signatures, respJSON };
 };
 
 // const getFirstSig = async (url: string) => {


### PR DESCRIPTION
## Problem

Claims (and add-wrapped-token) were failing with:

```
Access to fetch at 'https://3jb2sp2i7x27....lambda-url.eu-north-1.on.aws/auth?...'
blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present
GET ... net::ERR_FAILED 403 (Forbidden)
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'json')
```

The bridge uses a **3-of-4 signature server** design (`requiredSignatures = 3`, four `sigs[]` URLs), so a single failing server should be a non-event. But one server — `sigs[2]` (`3jb2sp2i7x27...`) — started returning **HTTP 403 with no CORS header**, and three bugs in `getSignatures.ts` turned that one bad server into a total claim failure:

1. **`fetchSig` returned `undefined` on a thrown fetch error** — the `setTimeout` retry result was never returned, so the next line `resp.json()` threw `Cannot read 'json' of undefined`.
2. **No per-server error isolation** — the collection loop had no `try/catch`, so the throw aborted the loop before the 4th server was ever tried, defeating the 3-of-4 redundancy.
3. **Runaway retries** — `setTimeout(() => fetchSig(url), 1000)` was fire-and-forget recursion that re-hit the dead server every second indefinitely (the flood of identical console errors).

This is why it "worked before": the redundancy masked the latent fragility as long as all four servers were healthy. The moment one started 403'ing, the code crashed instead of falling back.

## Fix

Rewrote signature collection so each server failure (network, CORS, HTTP error, or unparsable body) returns `null` and is **skipped**, letting the round continue across all four servers until the required signatures are gathered. Retries are now bounded (2 attempts) and properly awaited — no more background flood. Applied to both the claim flow (`getSignaturesClaim`) and the add-wrapped-token flow (`getSignaturesAddWrapped`).

## Result

As long as any **3 of the 4** servers respond, claims work again — routing around the broken `3jb2sp2i7x27...` server.

## Note for operators

This makes the frontend resilient, but the root cause is still server-side: that signature Lambda (`3jb2sp2i7x27xmcol2qsetcvse0jgtzp`, eu-north-1) is returning 403 with no CORS headers. It should be restored to get back to full 4-server redundancy (check the Function URL: auth type flipped to `AWS_IAM`, missing `lambda:InvokeFunctionUrl` resource policy, or cleared CORS config). If a second server is also down, only 2 would be healthy and no frontend change can produce a 3rd signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcEKVDSXfT5yzHv5qbzzBA)_