### PR TITLE
Fix Prettier formatting that broke the Netlify build

### DIFF
--- a/src/app/utils/getSignatures.ts
+++ b/src/app/utils/getSignatures.ts
@@ -60,9 +60,7 @@ const getSignaturesClaim = async (hash: string, chainId: string) => {
 };
 
 export const getSignaturesAddWrapped = async (token: `0x${string}`, chainId: number) => {
-  const { signatures, respJSON } = await collectSignatures(
-    (base) => `${base}addToken?token=${token}&chain=${chainId}`
-  );
+  const { signatures, respJSON } = await collectSignatures((base) => `${base}addToken?token=${token}&chain=${chainId}`);
 
   if (signatures.length < requiredSignatures) {
     return { signatures: [], respJSON };


### PR DESCRIPTION
## Problem

The Netlify build for the previous fix (#9) failed at compile time on a Prettier rule, not a logic error:

```
src/app/utils/getSignatures.ts
  Line 63:60:  Replace `⏎····(base)·=>·...⏎··` with `(base)·=>·...`  prettier/prettier
Failed to compile.
```

`craco build` runs ESLint with the `prettier/prettier` rule as a hard error, so the multi-line `collectSignatures(...)` call in `getSignaturesAddWrapped` failed the build and blocked the deploy.

## Fix

Collapse that call onto a single line (it is exactly 120 chars, matching the repo's `printWidth: 120`), as Prettier itself prescribed. No behavior change — formatting only.

This unblocks the Netlify deploy of the claim/signature-server resilience fix from #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcEKVDSXfT5yzHv5qbzzBA)_